### PR TITLE
Fix image folder lookup and add other images formats support

### DIFF
--- a/bereal_exporter.py
+++ b/bereal_exporter.py
@@ -104,7 +104,7 @@ class BeRealExporter:
       ext = os.path.splitext(old_img_name)[1].lower()
       if ext == ".webp":
         cp(old_img_name, img_name)
-      else:
+      elif ext in [".jpg", ".jpeg", ".tif", ".tiff"]:
         with Image.open(old_img_name) as im:
           im.save(img_name, "WEBP", quality=95)
 

--- a/bereal_exporter.py
+++ b/bereal_exporter.py
@@ -4,6 +4,7 @@ from exiftool import ExifToolHelper as et
 from shutil import copy2 as cp
 from datetime import datetime as dt
 import argparse
+from PIL import Image
 
 
 
@@ -99,7 +100,14 @@ class BeRealExporter:
     self.verbose_msg(f"Export {old_img_name} image to {img_name}")
 
     if os.path.isfile(old_img_name):
-      cp(old_img_name, img_name)
+      # Handling different photo formats
+      ext = os.path.splitext(old_img_name)[1].lower()
+      if ext == ".webp":
+        cp(old_img_name, img_name)
+      else:
+        with Image.open(old_img_name) as im:
+          im.save(img_name, "WEBP", quality=95)
+
       tags = {"DateTimeOriginal": img_dt.strftime("%Y:%m:%d %H:%M:%S")}
       if img_location:
           self.verbose_msg(f"Add metadata to image:\n - DateTimeOriginal={img_dt}\n - GPS=({img_location['latitude']}, {img_location['longitude']})")

--- a/bereal_exporter.py
+++ b/bereal_exporter.py
@@ -138,7 +138,16 @@ class BeRealExporter:
 
       if self.time_span[0] <= memory_dt <= self.time_span[1]:
         for img_name, type in zip(img_names, types):
-          old_img_name = os.path.join(self.bereal_path, f"Photos/post/{self.get_img_filename(memory[type[0]])}")
+          
+          # Recreating local photo path from json file
+          json_path = memory[type[0]]['path'].lstrip("/")
+          parts = json_path.split("/")
+          if len(parts) > 3 and parts[0] == "Photos":
+              clean_path = os.path.join(parts[0], parts[2], *parts[3:])
+          else:
+              clean_path = json_path  # fallback
+          old_img_name = os.path.join(self.bereal_path, clean_path)
+          
           self.verbose_msg(f"Export Memory nr {i} {type[0]}:")
           if 'location' in memory:
             self.export_img(old_img_name, img_name, memory_dt, memory['location'])

--- a/bereal_exporter.py
+++ b/bereal_exporter.py
@@ -113,12 +113,12 @@ class BeRealExporter:
       cp(old_img_name, img_name)
       self.verbose_msg(f"Copied video file ({ext}) without metadata")
 
-      elif ext == ".webp":
-        cp(old_img_name, img_name)
+    elif ext == ".webp":
+      cp(old_img_name, img_name)
 
-      elif ext in [".jpg", ".jpeg", ".tif", ".tiff", ".png"]:
-        with Image.open(old_img_name) as im:
-          im.save(img_name, "WEBP", quality=95)
+    elif ext in [".jpg", ".jpeg", ".tif", ".tiff", ".png"]:
+      with Image.open(old_img_name) as im:
+        im.save(img_name, "WEBP", quality=95)
 
       tags = {"DateTimeOriginal": img_dt.strftime("%Y:%m:%d %H:%M:%S")}
       if img_location:

--- a/bereal_exporter.py
+++ b/bereal_exporter.py
@@ -109,14 +109,14 @@ class BeRealExporter:
           })
       else:
           self.verbose_msg(f"Add metadata to image:\n - DateTimeOriginal={img_dt}")
- 
-      if self.exiftool_path:
-        et(executable=self.exiftool_path).set_tags(img_name, tags=tags, params=["-P", "-overwrite_original"])
-      else:
-        et().set_tags(img_name, tags=tags, params=["-P", "-overwrite_original"])
-    else:
-      self.verbose_msg(f"File {old_img_name} not found. Skipping this image.")
 
+      ext = os.path.splitext(img_name)[1].lower()
+      if ext in [".jpg", ".jpeg", ".tif", ".tiff"]:
+        with et(executable=self.exiftool_path) if self.exiftool_path else et() as exif:
+          exif.set_tags(img_name, tags=tags, params=["-P", "-overwrite_original"])
+
+      else:
+        self.verbose_msg(f"Skipping EXIF metadata for {img_name} (unsupported format: {ext})")
 
   def export_memories(self, memories: list):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyexiftool=0.5.6
+Pillow pyexiftool


### PR DESCRIPTION
Updated the code to use the image folder specified in the memories.json file instead of the hardcoded Photos/post path, and adds support for JPEG files in addition to JPG and TIFF formats.